### PR TITLE
Adding admin method to download all users

### DIFF
--- a/index.js
+++ b/index.js
@@ -259,7 +259,7 @@ function keycloak ({ pages = {}, realm, url, id, backend = false } = {}) {
     }
   }
 
-  async function verify (accessToken) {
+  async function verify ({ accessToken } = {}) {
     debug('Verifying that access token will work')
     if (!accessToken) throw Error(ERR_MISSING_ACCESS_TOKEN)
 
@@ -328,6 +328,7 @@ function keycloak ({ pages = {}, realm, url, id, backend = false } = {}) {
   }
 
   async function signout (tokens = {}) {
+    debug('Signing out!')
     const { accessToken, refreshToken } = tokens
     if (!accessToken) throw Error(ERR_MISSING_ACCESS_TOKEN)
     if (!refreshToken) throw Error(ERR_MISSING_REFRESH_TOKEN)
@@ -338,7 +339,7 @@ function keycloak ({ pages = {}, realm, url, id, backend = false } = {}) {
     await got.post(endpoints.logouts, {
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
-        Authorization: accessToken,
+        Authorization: `Bearer ${accessToken}`,
         'Content-Length': data.length
       },
       body: data

--- a/index.js
+++ b/index.js
@@ -113,9 +113,7 @@ function keycloak ({ pages = {}, realm, url, id, backend = false } = {}) {
   endpoints.resets = `${url}/realms/${realm}/login-actions/reset-credentials`
   endpoints.logins = `${url}/realms/${realm}/protocol/openid-connect/auth`
   endpoints.logouts = `${url}/realms/${realm}/protocol/openid-connect/logout`
-  endpoints.admin = {
-    allUsers: `${url}/admin/realms/${realm}/users`
-  }
+  endpoints.users = `${url}/admin/realms/${realm}/users`
 
   if (backend) {
     return dbg({
@@ -351,12 +349,12 @@ function keycloak ({ pages = {}, realm, url, id, backend = false } = {}) {
     }).json()
   }
 
-  async function allUsers ({ accessToken } = {}, next = 0, limit = 100, filters = {}) {
+  async function allUsers ({ accessToken } = {}, { next = 0, limit = 100, filters = {} } = {}) {
     debug('Getting all the users')
     if (!accessToken) throw Error(ERR_MISSING_ACCESS_TOKEN)
 
     try {
-      const users = await got(endpoints.admin.allUsers, {
+      const users = await got(endpoints.users, {
         headers: {
           Authorization: `Bearer ${accessToken}`
         },

--- a/index.js
+++ b/index.js
@@ -128,7 +128,7 @@ function keycloak ({ pages = {}, realm, url, id, backend = false } = {}) {
       async signup () { throw Error(ERR_BACKEND_METHOD_NOT_SUPPORTED('signup')) },
       reset () { throw Error(ERR_BACKEND_METHOD_NOT_SUPPORTED('reset')) },
       verify,
-      allUsers
+      users
     }, { endpoints })
   }
 
@@ -349,7 +349,7 @@ function keycloak ({ pages = {}, realm, url, id, backend = false } = {}) {
     }).json()
   }
 
-  async function allUsers ({ accessToken } = {}, { next = 0, limit = 100, filters = {} } = {}) {
+  async function users ({ accessToken } = {}, { next = 0, limit = 100, filters = {} } = {}) {
     debug('Getting all the users')
     if (!accessToken) throw Error(ERR_MISSING_ACCESS_TOKEN)
 
@@ -388,6 +388,6 @@ function keycloak ({ pages = {}, realm, url, id, backend = false } = {}) {
   }
 
   return dbg({
-    signup, signin, signout, validate, identity, refresh, reset, verify, allUsers
+    signup, signin, signout, validate, identity, refresh, reset, verify, users
   }, { endpoints })
 }

--- a/readme.md
+++ b/readme.md
@@ -67,6 +67,26 @@ Will open a browser at a Keycloak password reset URL, which differs based on the
 
 Returns a promise that resolves the teams for the user that the tokens belong to.
 
+### `instance.verify(tokens) => Promise => boolean`
+
+Verify that Keycloak will accept the token as valid by making an authorized request to Keycloak.
+
+### `instance.allUsers(tokens, next, limit, filters) => Promise => pagedUser`
+
+Page through all users in Keycloak.
+
+**Arguments:**
+
+* `tokens` - `accessToken` is required
+* `next` - which indexed user to start from
+* `limit` - how many users to get in each request
+* `filters` - see available filters on [Keycloak website](https://www.keycloak.org/docs-api/12.0/rest-api/#_getusers) (note: `first` and `max` will be ignored)
+
+**`pagedUser`:**
+
+* `next` _int | null_ - the `next` parameter to get the next page or `null` if no more results
+* `limit` _int_ - always matches the limit passed by developer
+* `users` _Array<User>_ - see `UserRepresentation` on [Keycloak website](https://www.keycloak.org/docs-api/12.0/rest-api/#_userrepresentation)
 
 ### `instance.validate(tokens) => boolean`
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -698,7 +698,7 @@ test('signout', async ({ is, teardown }) => {
   server.close()
 })
 
-test('admin allUsers input validation', async ({ rejects }) => {
+test('admin users input validation', async ({ rejects }) => {
   await rejects(keycloak({
     pages: {
       signup: Buffer.from('signup'), signin: Buffer.from('signin'), error: Buffer.from('error')
@@ -706,10 +706,10 @@ test('admin allUsers input validation', async ({ rejects }) => {
     realm: 'test',
     url: 'http://localhost:8080',
     id: 'test-id'
-  }).allUsers(), Error(ERR_MISSING_ACCESS_TOKEN))
+  }).users(), Error(ERR_MISSING_ACCESS_TOKEN))
 })
 
-test('admin allUsers success', async ({ is, match, teardown }) => {
+test('admin users success', async ({ is, match, teardown }) => {
   const server = createServer()
   teardown(() => server.close())
   await promisify(server.listen.bind(server))()
@@ -721,7 +721,7 @@ test('admin allUsers success', async ({ is, match, teardown }) => {
     realm: 'test',
     url: service,
     id: 'test-id'
-  }).allUsers({ accessToken: 'at' })
+  }).users({ accessToken: 'at' })
 
   const [req, res] = await once(server, 'request')
   is(req.url, '/admin/realms/test/users?first=0&max=100')
@@ -758,41 +758,37 @@ test('admin allUsers success', async ({ is, match, teardown }) => {
   ]))
 
   const parsed = await transaction
-  match(parsed, {
-    next: null,
-    limit: 100,
-    users: [
-      {
-        id: 'your-classic-guid',
-        createdTimestamp: 1614972520,
-        username: 'matthewctoai',
-        emailVerified: true,
-        firstName: 'm',
-        lastName: 'c',
-        email: 'matthew@cto.ai',
-        attributes: {
-          organizationRole: ['engineer'],
-          terms_and_conditions: ['1602112992']
-        },
-        enabled: true,
-        totp: false,
-        disableableCredentialTypes: [],
-        requiredActions: [],
-        notBefore: 0,
-        access: {
-          manageGroupMembership: false,
-          view: true,
-          mapRoles: false,
-          impersonate: false,
-          manage: false
-        }
+  match(parsed, [
+    {
+      id: 'your-classic-guid',
+      createdTimestamp: 1614972520,
+      username: 'matthewctoai',
+      emailVerified: true,
+      firstName: 'm',
+      lastName: 'c',
+      email: 'matthew@cto.ai',
+      attributes: {
+        organizationRole: ['engineer'],
+        terms_and_conditions: ['1602112992']
+      },
+      enabled: true,
+      totp: false,
+      disableableCredentialTypes: [],
+      requiredActions: [],
+      notBefore: 0,
+      access: {
+        manageGroupMembership: false,
+        view: true,
+        mapRoles: false,
+        impersonate: false,
+        manage: false
       }
-    ]
-  })
+    }
+  ])
   server.close()
 })
 
-test('admin allUsers paged', async ({ is, match, teardown }) => {
+test('admin users paged', async ({ is, match, teardown }) => {
   const server = createServer()
   teardown(() => server.close())
   await promisify(server.listen.bind(server))()
@@ -807,7 +803,7 @@ test('admin allUsers paged', async ({ is, match, teardown }) => {
     id: 'test-id'
   })
 
-  const firstTransaction = kc.allUsers({ accessToken: 'at' }, { next: 0, limit: 1 })
+  const getUsers = kc.users({ accessToken: 'at' }, { from: 0, to: 1 })
   let [req, res] = await once(server, 'request')
   is(req.url, '/admin/realms/test/users?first=0&max=1')
   const { headers } = req
@@ -816,23 +812,22 @@ test('admin allUsers paged', async ({ is, match, teardown }) => {
   res.setHeader('content-type', 'application/json')
   res.end(JSON.stringify([{ id: 'your-classic-uuid' }]))
 
-  let parsed = await firstTransaction
-  match(parsed, { next: 1, limit: 1, users: [{ id: 'your-classic-uuid' }] })
+  let parsed = await getUsers
+  match(parsed, [{ id: 'your-classic-uuid' }])
 
   // pass the values from the result of the first transaction to the next request
-  const secondTransaction = kc.allUsers({ accessToken: 'at' }, { next: parsed.next, limit: parsed.limit });
-  [req, res] = await once(server, 'request')
+  ;[req, res] = await once(server, 'request')
   is(req.url, '/admin/realms/test/users?first=1&max=1')
   res.setHeader('content-type', 'application/json')
   res.end(JSON.stringify([]))
 
-  parsed = await secondTransaction
-  match(parsed, { next: null, limit: 1, users: [] })
+  parsed = await getUsers.next()
+  match(parsed, [])
 
   server.close()
 })
 
-test('admin allUsers forbidden', async ({ is, teardown, rejects }) => {
+test('admin users forbidden', async ({ is, teardown, rejects }) => {
   const server = createServer()
   teardown(() => server.close())
   await promisify(server.listen.bind(server))()
@@ -844,7 +839,7 @@ test('admin allUsers forbidden', async ({ is, teardown, rejects }) => {
     realm: 'test',
     url: service,
     id: 'test-id'
-  }).allUsers({ accessToken: 'not-enough-perms' })
+  }).users({ accessToken: 'not-enough-perms' })
 
   const [req, res] = await once(server, 'request')
   is(req.url, '/admin/realms/test/users?first=0&max=100')
@@ -862,7 +857,7 @@ test('admin allUsers forbidden', async ({ is, teardown, rejects }) => {
   server.close()
 })
 
-test('admin allUsers generic error', async ({ is, teardown, rejects }) => {
+test('admin users generic error', async ({ is, teardown, rejects }) => {
   const server = createServer()
   teardown(() => server.close())
   await promisify(server.listen.bind(server))()
@@ -874,7 +869,7 @@ test('admin allUsers generic error', async ({ is, teardown, rejects }) => {
     realm: 'test',
     url: service,
     id: 'test-id'
-  }).allUsers({ accessToken: 'not-enough-perms' })
+  }).users({ accessToken: 'not-enough-perms' })
 
   const [req, res] = await once(server, 'request')
   is(req.url, '/admin/realms/test/users?first=0&max=100')

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -713,7 +713,7 @@ test('admin allUsers input validation', async ({ rejects }) => {
   }).allUsers(), Error(ERR_MISSING_ACCESS_TOKEN))
 })
 
-test('admin allUsers success', async ({ is, teardown }) => {
+test('admin allUsers success', async ({ is, match, teardown }) => {
   const server = createServer()
   teardown(() => server.close())
   await promisify(server.listen.bind(server))()
@@ -735,9 +735,38 @@ test('admin allUsers success', async ({ is, teardown }) => {
   res.setHeader('content-type', 'application/json')
   res.end(JSON.stringify([
     {
-      limit: 100,
-      next: null,
-      users: {
+      id: 'your-classic-guid',
+      createdTimestamp: 1614972520,
+      username: 'matthewctoai',
+      emailVerified: true,
+      firstName: 'm',
+      lastName: 'c',
+      email: 'matthew@cto.ai',
+      attributes: {
+        organizationRole: ['engineer'],
+        terms_and_conditions: ['1602112992']
+      },
+      enabled: true,
+      totp: false,
+      disableableCredentialTypes: [],
+      requiredActions: [],
+      notBefore: 0,
+      access: {
+        manageGroupMembership: false,
+        view: true,
+        mapRoles: false,
+        impersonate: false,
+        manage: false
+      }
+    }
+  ]))
+
+  const parsed = await transaction
+  match(parsed, {
+    next: null,
+    limit: 100,
+    users: [
+      {
         id: 'your-classic-guid',
         createdTimestamp: 1614972520,
         username: 'matthewctoai',
@@ -762,10 +791,8 @@ test('admin allUsers success', async ({ is, teardown }) => {
           manage: false
         }
       }
-    }
-  ]))
-
-  await transaction
+    ]
+  })
   server.close()
 })
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -256,9 +256,7 @@ test('exposes endpoints', async ({ same }) => {
       resets: 'http://localhost:9999/realms/test/login-actions/reset-credentials',
       logins: 'http://localhost:9999/realms/test/protocol/openid-connect/auth',
       logouts: 'http://localhost:9999/realms/test/protocol/openid-connect/logout',
-      admin: {
-        allUsers: 'http://localhost:9999/admin/realms/test/users'
-      }
+      users: 'http://localhost:9999/admin/realms/test/users'
     })
   }
 
@@ -281,9 +279,7 @@ test('exposes endpoints', async ({ same }) => {
       resets: 'http://localhost:9999/realms/test/login-actions/reset-credentials',
       logins: 'http://localhost:9999/realms/test/protocol/openid-connect/auth',
       logouts: 'http://localhost:9999/realms/test/protocol/openid-connect/logout',
-      admin: {
-        allUsers: 'http://localhost:9999/admin/realms/test/users'
-      }
+      users: 'http://localhost:9999/admin/realms/test/users'
     })
   }
 })
@@ -811,7 +807,7 @@ test('admin allUsers paged', async ({ is, match, teardown }) => {
     id: 'test-id'
   })
 
-  const firstTransaction = kc.allUsers({ accessToken: 'at' }, 0, 1)
+  const firstTransaction = kc.allUsers({ accessToken: 'at' }, { next: 0, limit: 1 })
   let [req, res] = await once(server, 'request')
   is(req.url, '/admin/realms/test/users?first=0&max=1')
   const { headers } = req
@@ -824,7 +820,7 @@ test('admin allUsers paged', async ({ is, match, teardown }) => {
   match(parsed, { next: 1, limit: 1, users: [{ id: 'your-classic-uuid' }] })
 
   // pass the values from the result of the first transaction to the next request
-  const secondTransaction = kc.allUsers({ accessToken: 'at' }, parsed.next, parsed.limit);
+  const secondTransaction = kc.allUsers({ accessToken: 'at' }, { next: parsed.next, limit: parsed.limit });
   [req, res] = await once(server, 'request')
   is(req.url, '/admin/realms/test/users?first=1&max=1')
   res.setHeader('content-type', 'application/json')

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -685,6 +685,7 @@ test('signout', async ({ is, teardown }) => {
   const { headers } = req
   is(headers['content-type'], 'application/x-www-form-urlencoded')
   is(headers['content-length'], '34')
+  is(headers.authorization, 'Bearer at')
   const [data] = await once(req, 'data')
   const body = qs.parse(data.toString())
   is(body.client_id, 'test-id')
@@ -857,7 +858,7 @@ test('verify', async ({ is, teardown }) => {
     realm: 'test',
     url: service,
     id: 'test-id'
-  }).verify('at')
+  }).verify({ accessToken: 'at' })
 
   const [req, res] = await once(server, 'request')
   is(req.url, '/realms/test/protocol/openid-connect/userinfo')
@@ -890,7 +891,7 @@ test('verify unauthorized request', async ({ is, teardown }) => {
     realm: 'test',
     url: service,
     id: 'test-id'
-  }).verify('at')
+  }).verify({ accessToken: 'at' })
 
   const [req, res] = await once(server, 'request')
   is(req.url, '/realms/test/protocol/openid-connect/userinfo')
@@ -917,7 +918,7 @@ test('verify some failure in keycloak', async ({ is, teardown, rejects }) => {
     realm: 'test',
     url: service,
     id: 'test-id'
-  }).verify('at')
+  }).verify({ accessToken: 'at' })
 
   const [req, res] = await once(server, 'request')
   is(req.url, '/realms/test/protocol/openid-connect/userinfo')

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -698,7 +698,7 @@ test('signout', async ({ is, teardown }) => {
   server.close()
 })
 
-test('admin allUsers input validation', async ({ rejects }) => {
+test('admin users input validation', async ({ rejects }) => {
   await rejects(keycloak({
     pages: {
       signup: Buffer.from('signup'), signin: Buffer.from('signin'), error: Buffer.from('error')
@@ -706,10 +706,10 @@ test('admin allUsers input validation', async ({ rejects }) => {
     realm: 'test',
     url: 'http://localhost:8080',
     id: 'test-id'
-  }).allUsers(), Error(ERR_MISSING_ACCESS_TOKEN))
+  }).users(), Error(ERR_MISSING_ACCESS_TOKEN))
 })
 
-test('admin allUsers success', async ({ is, match, teardown }) => {
+test('admin users success', async ({ is, match, teardown }) => {
   const server = createServer()
   teardown(() => server.close())
   await promisify(server.listen.bind(server))()
@@ -721,7 +721,7 @@ test('admin allUsers success', async ({ is, match, teardown }) => {
     realm: 'test',
     url: service,
     id: 'test-id'
-  }).allUsers({ accessToken: 'at' })
+  }).users({ accessToken: 'at' })
 
   const [req, res] = await once(server, 'request')
   is(req.url, '/admin/realms/test/users?first=0&max=100')
@@ -792,7 +792,7 @@ test('admin allUsers success', async ({ is, match, teardown }) => {
   server.close()
 })
 
-test('admin allUsers paged', async ({ is, match, teardown }) => {
+test('admin users paged', async ({ is, match, teardown }) => {
   const server = createServer()
   teardown(() => server.close())
   await promisify(server.listen.bind(server))()
@@ -807,7 +807,7 @@ test('admin allUsers paged', async ({ is, match, teardown }) => {
     id: 'test-id'
   })
 
-  const firstTransaction = kc.allUsers({ accessToken: 'at' }, { next: 0, limit: 1 })
+  const firstTransaction = kc.users({ accessToken: 'at' }, { next: 0, limit: 1 })
   let [req, res] = await once(server, 'request')
   is(req.url, '/admin/realms/test/users?first=0&max=1')
   const { headers } = req
@@ -820,7 +820,7 @@ test('admin allUsers paged', async ({ is, match, teardown }) => {
   match(parsed, { next: 1, limit: 1, users: [{ id: 'your-classic-uuid' }] })
 
   // pass the values from the result of the first transaction to the next request
-  const secondTransaction = kc.allUsers({ accessToken: 'at' }, { next: parsed.next, limit: parsed.limit });
+  const secondTransaction = kc.users({ accessToken: 'at' }, { next: parsed.next, limit: parsed.limit });
   [req, res] = await once(server, 'request')
   is(req.url, '/admin/realms/test/users?first=1&max=1')
   res.setHeader('content-type', 'application/json')
@@ -832,7 +832,7 @@ test('admin allUsers paged', async ({ is, match, teardown }) => {
   server.close()
 })
 
-test('admin allUsers forbidden', async ({ is, teardown, rejects }) => {
+test('admin users forbidden', async ({ is, teardown, rejects }) => {
   const server = createServer()
   teardown(() => server.close())
   await promisify(server.listen.bind(server))()
@@ -844,7 +844,7 @@ test('admin allUsers forbidden', async ({ is, teardown, rejects }) => {
     realm: 'test',
     url: service,
     id: 'test-id'
-  }).allUsers({ accessToken: 'not-enough-perms' })
+  }).users({ accessToken: 'not-enough-perms' })
 
   const [req, res] = await once(server, 'request')
   is(req.url, '/admin/realms/test/users?first=0&max=100')
@@ -862,7 +862,7 @@ test('admin allUsers forbidden', async ({ is, teardown, rejects }) => {
   server.close()
 })
 
-test('admin allUsers generic error', async ({ is, teardown, rejects }) => {
+test('admin users generic error', async ({ is, teardown, rejects }) => {
   const server = createServer()
   teardown(() => server.close())
   await promisify(server.listen.bind(server))()
@@ -874,7 +874,7 @@ test('admin allUsers generic error', async ({ is, teardown, rejects }) => {
     realm: 'test',
     url: service,
     id: 'test-id'
-  }).allUsers({ accessToken: 'not-enough-perms' })
+  }).users({ accessToken: 'not-enough-perms' })
 
   const [req, res] = await once(server, 'request')
   is(req.url, '/admin/realms/test/users?first=0&max=100')

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -824,7 +824,7 @@ test('admin allUsers paged', async ({ is, match, teardown }) => {
   match(parsed, { next: 1, limit: 1, users: [{ id: 'your-classic-uuid' }] })
 
   // pass the values from the result of the first transaction to the next request
-  const secondTransaction = kc.allUsers({ accessToken: 'at' }, 1, 1);
+  const secondTransaction = kc.allUsers({ accessToken: 'at' }, parsed.next, parsed.limit);
   [req, res] = await once(server, 'request')
   is(req.url, '/admin/realms/test/users?first=1&max=1')
   res.setHeader('content-type', 'application/json')


### PR DESCRIPTION
The Keycloak endpoint being called is a paged endpoint but there are no headers or response body that informs a user how far they are so I have tried to add that context.

Also included:

* a change to `verify` to match the structure of the other methods
* added `Bearer` to the `Authorization` header when signing out (seems to have been done incorrectly in the CLI)

The signin and signout process seems to be a little different for the admin endpoints so I don't know if we should already move the `allUsers` method into an `admin` namespace when exporting.